### PR TITLE
Separate connect/refresh in tree data provider

### DIFF
--- a/client/src/commands/connectCommand.ts
+++ b/client/src/commands/connectCommand.ts
@@ -17,6 +17,7 @@ import { Util } from './util';
 import { FabricClientConnection } from '../fabricClientConnection';
 import { ParsedCertificate } from '../parsedCertificate';
 import { getBlockchainNetworkExplorerProvider } from '../extension';
+import { FabricConnectionManager } from '../fabric/FabricConnectionManager';
 
 export async function connect(connection: any): Promise<void> {
     console.log('connect');
@@ -70,9 +71,7 @@ export async function connect(connection: any): Promise<void> {
     try {
         const fabricConnection: FabricClientConnection = new FabricClientConnection(connection);
         await fabricConnection.connect();
-
-        const blockchainNetworkExplorerProvider = getBlockchainNetworkExplorerProvider();
-        await blockchainNetworkExplorerProvider.connect(fabricConnection);
+        FabricConnectionManager.instance().connect(fabricConnection);
     } catch (error) {
         vscode.window.showErrorMessage(error.message);
         throw error;

--- a/client/src/commands/connectCommand.ts
+++ b/client/src/commands/connectCommand.ts
@@ -16,15 +16,16 @@ import * as vscode from 'vscode';
 import { Util } from './util';
 import { FabricClientConnection } from '../fabricClientConnection';
 import { ParsedCertificate } from '../parsedCertificate';
+import { getBlockchainNetworkExplorerProvider } from '../extension';
 
-export async function connect(connection: any): Promise<{} | string | void> {
+export async function connect(connection: any): Promise<void> {
     console.log('connect');
 
     if (!connection) {
         const connectionName: string = await Util.showConnectionQuickPickBox('Choose a connection to connect with');
 
         if (!connectionName) {
-            return Promise.resolve();
+            return;
         }
 
         const connections: Array<any> = vscode.workspace.getConfiguration().get('fabric.connections');
@@ -34,7 +35,7 @@ export async function connect(connection: any): Promise<{} | string | void> {
 
         if (!connectionConfig) {
             vscode.window.showErrorMessage('Could not connect as no connection found');
-            return Promise.resolve();
+            return;
         }
 
         connection = {
@@ -45,7 +46,7 @@ export async function connect(connection: any): Promise<{} | string | void> {
             const identityName = await Util.showIdentityConnectionQuickPickBox('Choose an identity to connect with', connectionConfig);
 
             if (!identityName) {
-                return Promise.resolve();
+                return;
             }
 
             const foundIdentity = connectionConfig.identities.find(((identity) => {
@@ -55,7 +56,7 @@ export async function connect(connection: any): Promise<{} | string | void> {
 
             if (!foundIdentity) {
                 vscode.window.showErrorMessage('Could not connect as no identity found');
-                return Promise.resolve();
+                return;
             }
 
             connection.certificatePath = foundIdentity.certificatePath;
@@ -70,9 +71,10 @@ export async function connect(connection: any): Promise<{} | string | void> {
         const fabricConnection: FabricClientConnection = new FabricClientConnection(connection);
         await fabricConnection.connect();
 
-        return vscode.commands.executeCommand('blockchainExplorer.refreshEntry', fabricConnection);
+        const blockchainNetworkExplorerProvider = getBlockchainNetworkExplorerProvider();
+        await blockchainNetworkExplorerProvider.connect(fabricConnection);
     } catch (error) {
         vscode.window.showErrorMessage(error.message);
-        return Promise.reject(error);
+        throw error;
     }
 }

--- a/client/src/explorer/BlockchainExplorerProvider.ts
+++ b/client/src/explorer/BlockchainExplorerProvider.ts
@@ -11,15 +11,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
-'use strict';
-import { BlockchainTreeItem } from './BlockchainTreeItem';
+
 import * as vscode from 'vscode';
-import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
+import { BlockchainTreeItem } from './model/BlockchainTreeItem';
 
-export class ChannelTreeItem extends BlockchainTreeItem {
-    contextValue = 'blockchain-channel-item';
+export interface BlockchainExplorerProvider extends vscode.TreeDataProvider<BlockchainTreeItem> {
 
-    constructor(provider: BlockchainExplorerProvider, private readonly channelName: string, public readonly peers: Array<string>, public readonly chaincodes: Array<any>, public readonly collapsibleState: vscode.TreeItemCollapsibleState) {
-        super(provider, channelName, collapsibleState);
-    }
+    refresh(element?: BlockchainTreeItem): Promise<void>;
+
 }

--- a/client/src/explorer/BlockchainNetworkExplorer.ts
+++ b/client/src/explorer/BlockchainNetworkExplorer.ts
@@ -43,14 +43,17 @@ export class BlockchainNetworkExplorerProvider implements vscode.TreeDataProvide
 
     private connection: FabricClientConnection = null;
 
-    async refresh(connection?: FabricClientConnection): Promise<void> {
-        console.log('refresh', connection);
-        if (connection) {
-            this.connection = connection;
-            // This controls which menu buttons appear
-            await vscode.commands.executeCommand('setContext', 'blockchain-connected', true);
-        }
-        this._onDidChangeTreeData.fire();
+    async refresh(element?: BlockchainTreeItem): Promise<void> {
+        console.log('refresh', element);
+        this._onDidChangeTreeData.fire(element);
+    }
+
+    async connect(connection: FabricClientConnection): Promise<void> {
+        console.log('connect', connection);
+        this.connection = connection;
+        // This controls which menu buttons appear
+        await vscode.commands.executeCommand('setContext', 'blockchain-connected', true);
+        await this.refresh();
     }
 
     async disconnect(): Promise<void> {
@@ -58,7 +61,7 @@ export class BlockchainNetworkExplorerProvider implements vscode.TreeDataProvide
         this.connection = null;
         // This controls which menu buttons appear
         await vscode.commands.executeCommand('setContext', 'blockchain-connected', false);
-        return this.refresh();
+        await this.refresh();
     }
 
     test(data): Promise<void> {

--- a/client/src/explorer/BlockchainPackageExplorer.ts
+++ b/client/src/explorer/BlockchainPackageExplorer.ts
@@ -16,10 +16,11 @@ import { PackageTreeItem } from './model/PackageTreeItem';
 import * as fs from 'fs';
 import * as util from 'util';
 import * as path from 'path';
+import { BlockchainExplorerProvider } from './BlockchainExplorerProvider';
 const readDir = util.promisify(fs.readdir);
 const readFile = util.promisify(fs.readFile);
 
-export class BlockchainPackageExplorerProvider implements vscode.TreeDataProvider<PackageTreeItem> {
+export class BlockchainPackageExplorerProvider implements BlockchainExplorerProvider {
     public tree: Array<PackageTreeItem> = [];
     private packageArray: Array<any>;
     private packageDir: string;
@@ -76,7 +77,7 @@ export class BlockchainPackageExplorerProvider implements vscode.TreeDataProvide
             } catch (error) {
                 console.log('failed to get smart contract package version', error.message);
             } finally {
-                tree.push(new PackageTreeItem(packageTitle));
+                tree.push(new PackageTreeItem(this, packageTitle));
             }
         }
         return tree;

--- a/client/src/explorer/model/AddConnectionTreeItem.ts
+++ b/client/src/explorer/model/AddConnectionTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
 import * as vscode from 'vscode';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class AddConnectionTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-add-connection-item';
 
-    constructor(public readonly label: string, public readonly command: vscode.Command) {
-        super(label, vscode.TreeItemCollapsibleState.None);
+    constructor(provider: BlockchainExplorerProvider, public readonly label: string, public readonly command: vscode.Command) {
+        super(provider, label, vscode.TreeItemCollapsibleState.None);
     }
 }

--- a/client/src/explorer/model/BlockchainTreeItem.ts
+++ b/client/src/explorer/model/BlockchainTreeItem.ts
@@ -14,7 +14,7 @@
 'use strict';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { getBlockchainNetworkExplorerProvider } from '../../extension';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export abstract class BlockchainTreeItem extends vscode.TreeItem {
     // TODO: update the icons
@@ -24,7 +24,7 @@ export abstract class BlockchainTreeItem extends vscode.TreeItem {
     };
     contextValue = 'blockchain-tree-item';
 
-    constructor(public readonly label: string, public readonly collapsibleState: vscode.TreeItemCollapsibleState) {
+    constructor(private readonly provider: BlockchainExplorerProvider, public readonly label: string, public readonly collapsibleState: vscode.TreeItemCollapsibleState) {
         super(label, collapsibleState);
     }
 
@@ -33,6 +33,6 @@ export abstract class BlockchainTreeItem extends vscode.TreeItem {
     }
 
     refresh(): void {
-        getBlockchainNetworkExplorerProvider().refresh(this);
+        this.provider.refresh(this);
     }
 }

--- a/client/src/explorer/model/BlockchainTreeItem.ts
+++ b/client/src/explorer/model/BlockchainTreeItem.ts
@@ -14,6 +14,7 @@
 'use strict';
 import * as vscode from 'vscode';
 import * as path from 'path';
+import { getBlockchainNetworkExplorerProvider } from '../../extension';
 
 export abstract class BlockchainTreeItem extends vscode.TreeItem {
     // TODO: update the icons
@@ -29,5 +30,9 @@ export abstract class BlockchainTreeItem extends vscode.TreeItem {
 
     get tooltip(): string {
         return `${this.label}`;
+    }
+
+    refresh(): void {
+        getBlockchainNetworkExplorerProvider().refresh(this);
     }
 }

--- a/client/src/explorer/model/ChainCodeTreeItem.ts
+++ b/client/src/explorer/model/ChainCodeTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import * as vscode from 'vscode';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class ChainCodeTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-chaincode-item';
 
-    constructor(private readonly name: string) {
-        super(name, vscode.TreeItemCollapsibleState.None);
+    constructor(provider: BlockchainExplorerProvider, private readonly name: string) {
+        super(provider, name, vscode.TreeItemCollapsibleState.None);
     }
 }

--- a/client/src/explorer/model/ConnectionIdentityTreeItem.ts
+++ b/client/src/explorer/model/ConnectionIdentityTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
 import * as vscode from 'vscode';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class ConnectionIdentityTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-connection-identity-item';
 
-    constructor(public readonly label: string, public readonly command: vscode.Command) {
-        super(label, vscode.TreeItemCollapsibleState.None);
+    constructor(provider: BlockchainExplorerProvider, public readonly label: string, public readonly command: vscode.Command) {
+        super(provider, label, vscode.TreeItemCollapsibleState.None);
     }
 }

--- a/client/src/explorer/model/ConnectionTreeItem.ts
+++ b/client/src/explorer/model/ConnectionTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import * as vscode from 'vscode';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class ConnectionTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-connection-item';
 
-    constructor(public readonly label: string, public readonly connection: any, public readonly collapsableState: vscode.TreeItemCollapsibleState, public readonly command?: vscode.Command) {
-        super(label, collapsableState);
+    constructor(provider: BlockchainExplorerProvider, public readonly label: string, public readonly connection: any, public readonly collapsableState: vscode.TreeItemCollapsibleState, public readonly command?: vscode.Command) {
+        super(provider, label, collapsableState);
     }
 }

--- a/client/src/explorer/model/InstalledChainCodeTreeItem.ts
+++ b/client/src/explorer/model/InstalledChainCodeTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import * as vscode from 'vscode';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class InstalledChainCodeTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-installed-chaincode-item';
 
-    constructor(private readonly name: string, public readonly versions: Array<string>) {
-        super(name, vscode.TreeItemCollapsibleState.Collapsed);
+    constructor(provider: BlockchainExplorerProvider, private readonly name: string, public readonly versions: Array<string>) {
+        super(provider, name, vscode.TreeItemCollapsibleState.Collapsed);
     }
 }

--- a/client/src/explorer/model/InstalledChaincodeVersionTreeItem.ts
+++ b/client/src/explorer/model/InstalledChaincodeVersionTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import * as vscode from 'vscode';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class InstalledChainCodeVersionTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-installed-chaincode-version-item';
 
-    constructor(private readonly version: string) {
-        super(version, vscode.TreeItemCollapsibleState.None);
+    constructor(provider: BlockchainExplorerProvider, private readonly version: string) {
+        super(provider, version, vscode.TreeItemCollapsibleState.None);
     }
 }

--- a/client/src/explorer/model/InstantiatedChaincodesTreeItem.ts
+++ b/client/src/explorer/model/InstantiatedChaincodesTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
 import * as vscode from 'vscode';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class InstantiatedChainCodesTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-instantiated-chaincodes-item';
 
-    constructor(public readonly label: string, public readonly chaincodes: Array<any>) {
-        super(label, vscode.TreeItemCollapsibleState.Collapsed);
+    constructor(provider: BlockchainExplorerProvider, public readonly label: string, public readonly chaincodes: Array<any>) {
+        super(provider, label, vscode.TreeItemCollapsibleState.Collapsed);
     }
 }

--- a/client/src/explorer/model/PackageTreeItem.ts
+++ b/client/src/explorer/model/PackageTreeItem.ts
@@ -14,10 +14,11 @@
 'use strict';
 import * as vscode from 'vscode';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class PackageTreeItem extends BlockchainTreeItem {
 
-    constructor(public readonly name: string) {
-        super(name, vscode.TreeItemCollapsibleState.None);
+    constructor(provider: BlockchainExplorerProvider, public readonly name: string) {
+        super(provider, name, vscode.TreeItemCollapsibleState.None);
     }
 }

--- a/client/src/explorer/model/PeerTreeItem.ts
+++ b/client/src/explorer/model/PeerTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import * as vscode from 'vscode';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class PeerTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-peer-item';
 
-    constructor(private readonly peerName: any, public readonly chaincodes: Map<string, Array<string>>, collapsibleState: vscode.TreeItemCollapsibleState) {
-        super(peerName, collapsibleState);
+    constructor(provider: BlockchainExplorerProvider, private readonly peerName: any, public readonly chaincodes: Map<string, Array<string>>, collapsibleState: vscode.TreeItemCollapsibleState) {
+        super(provider, peerName, collapsibleState);
     }
 }

--- a/client/src/explorer/model/PeersTreeItem.ts
+++ b/client/src/explorer/model/PeersTreeItem.ts
@@ -14,11 +14,12 @@
 'use strict';
 import { BlockchainTreeItem } from './BlockchainTreeItem';
 import * as vscode from 'vscode';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
 
 export class PeersTreeItem extends BlockchainTreeItem {
     contextValue = 'blockchain-peers-item';
 
-    constructor(public readonly label: string, public readonly peers: Array<string>) {
-        super(label, vscode.TreeItemCollapsibleState.Collapsed);
+    constructor(provider: BlockchainExplorerProvider, public readonly label: string, public readonly peers: Array<string>) {
+        super(provider, label, vscode.TreeItemCollapsibleState.Collapsed);
     }
 }

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -33,7 +33,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     vscode.window.registerTreeDataProvider('blockchainExplorer', blockchainNetworkExplorerProvider);
     vscode.window.registerTreeDataProvider('blockchainAPackageExplorer', blockchainPackageExplorerProvider);
-    vscode.commands.registerCommand('blockchainExplorer.refreshEntry', (connection) => blockchainNetworkExplorerProvider.refresh(connection));
+    vscode.commands.registerCommand('blockchainExplorer.refreshEntry', (element) => blockchainNetworkExplorerProvider.refresh(element));
     vscode.commands.registerCommand('blockchainExplorer.connectEntry', (connection) => connect(connection));
     vscode.commands.registerCommand('blockchainExplorer.disconnectEntry', () => blockchainNetworkExplorerProvider.disconnect());
     vscode.commands.registerCommand('blockchainExplorer.addConnectionEntry', addConnection);

--- a/client/src/fabric/FabricConnectionManager.ts
+++ b/client/src/fabric/FabricConnectionManager.ts
@@ -1,0 +1,46 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { FabricClientConnection } from '../fabricClientConnection';
+import { EventEmitter } from 'events';
+
+export class FabricConnectionManager extends EventEmitter {
+
+    public static instance(): FabricConnectionManager {
+        return FabricConnectionManager._instance;
+    }
+
+    private static _instance: FabricConnectionManager = new FabricConnectionManager();
+
+    private connection: FabricClientConnection;
+
+    private constructor() {
+        super();
+    }
+
+    public getConnection(): FabricClientConnection {
+        return this.connection;
+    }
+
+    public connect(connection: FabricClientConnection) {
+        this.connection = connection;
+        this.emit('connected', connection);
+    }
+
+    public disconnect() {
+        this.connection = null;
+        this.emit('disconnected');
+    }
+
+}

--- a/client/test/explorer/blockchainNetworkExplorer.test.ts
+++ b/client/test/explorer/blockchainNetworkExplorer.test.ts
@@ -32,12 +32,48 @@ import { PeerTreeItem } from '../../src/explorer/model/PeerTreeItem';
 import { ChainCodeTreeItem } from '../../src/explorer/model/ChainCodeTreeItem';
 import { InstalledChainCodeTreeItem } from '../../src/explorer/model/InstalledChainCodeTreeItem';
 import { InstalledChainCodeVersionTreeItem } from '../../src/explorer/model/InstalledChaincodeVersionTreeItem';
+import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
 
 chai.use(sinonChai);
 const should = chai.should();
 
 // tslint:disable no-unused-expression
 describe('BlockchainNetworkExplorer', () => {
+
+    describe('constructor', () => {
+
+        let mySandBox: sinon.SinonSandbox;
+
+        beforeEach(() => {
+            mySandBox = sinon.createSandbox();
+        });
+
+        afterEach(() => {
+            mySandBox.restore();
+        });
+
+        it('should register for connected events from the connection manager', async () => {
+            await vscode.extensions.getExtension('hyperledger.hyperledger-fabric').activate();
+            const blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'connect').resolves();
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'disconnect').resolves();
+            const mockConnection: sinon.SinonStubbedInstance<FabricClientConnection> = sinon.createStubInstance(FabricClientConnection);
+            const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
+            connectionManager.emit('connected', mockConnection);
+            blockchainNetworkExplorerProvider.connect.should.have.been.calledOnceWithExactly(mockConnection);
+        });
+
+        it('should register for disconnected events from the connection manager', async () => {
+            await vscode.extensions.getExtension('hyperledger.hyperledger-fabric').activate();
+            const blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'connect').resolves();
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'disconnect').resolves();
+            const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
+            connectionManager.emit('disconnected');
+            blockchainNetworkExplorerProvider.disconnect.should.have.been.calledOnceWithExactly();
+        });
+
+    });
 
     describe('getChildren', () => {
 

--- a/client/test/explorer/model/BlockchainTreeItem.test.ts
+++ b/client/test/explorer/model/BlockchainTreeItem.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import { BlockchainTreeItem } from '../../../src/explorer/model/BlockchainTreeItem';
+import { getBlockchainNetworkExplorerProvider } from '../../../src/extension';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+
+chai.should();
+
+describe('BlockchainTreeItem', () => {
+
+    class TestBlockchainTreeItem extends BlockchainTreeItem {
+
+        constructor() {
+            super('test label', vscode.TreeItemCollapsibleState.None);
+        }
+
+    }
+
+    let sandbox: sinon.SinonSandbox;
+    let treeItem: TestBlockchainTreeItem;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        treeItem = new TestBlockchainTreeItem();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('#tooltip', () => {
+
+        it('should have the tooltip', () => {
+            treeItem.tooltip.should.equal('test label');
+        });
+
+    });
+
+    describe('#refresh', () => {
+
+        it('should refresh the tree data provider', () => {
+            const treeDataProvider = getBlockchainNetworkExplorerProvider();
+            const refreshStub = sandbox.stub(treeDataProvider, 'refresh');
+            treeItem.refresh();
+            refreshStub.should.have.been.calledOnceWithExactly(treeItem);
+        });
+
+    });
+
+});

--- a/client/test/explorer/model/BlockchainTreeItem.test.ts
+++ b/client/test/explorer/model/BlockchainTreeItem.test.ts
@@ -26,7 +26,7 @@ describe('BlockchainTreeItem', () => {
     class TestBlockchainTreeItem extends BlockchainTreeItem {
 
         constructor() {
-            super('test label', vscode.TreeItemCollapsibleState.None);
+            super(getBlockchainNetworkExplorerProvider(), 'test label', vscode.TreeItemCollapsibleState.None);
         }
 
     }

--- a/client/test/fabric/FabricConnectionManager.test.ts
+++ b/client/test/fabric/FabricConnectionManager.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import { FabricClientConnection } from '../../src/fabricClientConnection';
+
+const should = chai.should();
+
+describe('FabricConnectionManager', () => {
+
+    const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
+    let mockFabricConnection: sinon.SinonStubbedInstance<FabricClientConnection>;
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(async () => {
+        sandbox = sinon.createSandbox();
+        mockFabricConnection = sinon.createStubInstance(FabricClientConnection);
+        connectionManager['connection'] = null;
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+        connectionManager['connection'] = null;
+    });
+
+    describe('#getConnection', () => {
+
+        it('should get the connection', () => {
+            connectionManager['connection'] = ((mockFabricConnection as any) as FabricClientConnection);
+            connectionManager.getConnection().should.equal(mockFabricConnection);
+        });
+
+    });
+
+    describe('#connect', () => {
+
+        it('should store the connection and emit an event', () => {
+            const listenerStub = sinon.stub();
+            connectionManager.once('connected', listenerStub);
+            connectionManager.connect((mockFabricConnection as any) as FabricClientConnection);
+            connectionManager.getConnection().should.equal(mockFabricConnection);
+            listenerStub.should.have.been.calledOnceWithExactly(mockFabricConnection);
+        });
+
+    });
+
+    describe('#disconnect', () => {
+
+        it('should clear the connection and emit an event', () => {
+            const listenerStub = sinon.stub();
+            connectionManager.once('disconnected', listenerStub);
+            connectionManager.disconnect();
+            should.equal(connectionManager.getConnection(), null);
+            listenerStub.should.have.been.calledOnceWithExactly();
+        });
+
+    });
+
+});


### PR DESCRIPTION
`BlockchainNetworkExplorerProvider.refresh` handles two things:
- Refreshing the tree
- Setting the connection

The second part of this should be split into a new `connect` method.

The reason for _me_ doing this is that I want a tree item to have the ability to refresh itself, and to do this we need to pass the tree item into _onDidChangeTreeData(item). This tells VSCode to refresh just that tree item and its children, instead of the whole tree.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>