### PR TITLE
Separate client and runtime connections

### DIFF
--- a/client/src/commands/connectCommand.ts
+++ b/client/src/commands/connectCommand.ts
@@ -14,7 +14,7 @@
 'use strict';
 import * as vscode from 'vscode';
 import { Util } from './util';
-import { FabricClientConnection } from '../fabricClientConnection';
+import { FabricClientConnection } from '../fabric/FabricClientConnection';
 import { ParsedCertificate } from '../parsedCertificate';
 import { getBlockchainNetworkExplorerProvider } from '../extension';
 import { FabricConnectionManager } from '../fabric/FabricConnectionManager';

--- a/client/src/explorer/BlockchainNetworkExplorer.ts
+++ b/client/src/explorer/BlockchainNetworkExplorer.ts
@@ -16,7 +16,7 @@
 'use strict';
 import * as vscode from 'vscode';
 
-import { FabricClientConnection } from '../fabricClientConnection';
+import { FabricConnection } from '../fabric/FabricConnection';
 import { GenerateTests } from './generateTests';
 import { ParsedCertificate } from '../parsedCertificate';
 
@@ -43,10 +43,10 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
     // tslint:disable-next-line member-ordering
     readonly onDidChangeTreeData: vscode.Event<any | undefined> = this._onDidChangeTreeData.event;
 
-    private connection: FabricClientConnection = null;
+    private connection: FabricConnection = null;
 
     constructor() {
-        FabricConnectionManager.instance().on('connected', async (connection: FabricClientConnection) => {
+        FabricConnectionManager.instance().on('connected', async (connection: FabricConnection) => {
             try {
                 await this.connect(connection);
             } catch (error) {
@@ -67,7 +67,7 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
         this._onDidChangeTreeData.fire(element);
     }
 
-    async connect(connection: FabricClientConnection): Promise<void> {
+    async connect(connection: FabricConnection): Promise<void> {
         console.log('connect', connection);
         this.connection = connection;
         // This controls which menu buttons appear

--- a/client/src/fabric/FabricClientConnection.ts
+++ b/client/src/fabric/FabricClientConnection.ts
@@ -1,0 +1,52 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+'use strict';
+import {
+    loadFromConfig
+} from 'fabric-client';
+import * as fs from 'fs';
+import { FabricConnection } from './FabricConnection';
+
+const ENCODING = 'utf8';
+
+export class FabricClientConnection extends FabricConnection {
+
+    private connectionProfilePath: string;
+    private certificatePath: string;
+    private privateKeyPath: string;
+
+    constructor(connectionData) {
+        super();
+        this.connectionProfilePath = connectionData.connectionProfilePath;
+        this.certificatePath = connectionData.certificatePath;
+        this.privateKeyPath = connectionData.privateKeyPath;
+    }
+
+    async connect(): Promise<void> {
+        console.log('connect');
+        this.client = await loadFromConfig(this.connectionProfilePath);
+        const mspid: string = this.client.getMspid();
+        const certString: string = this.loadFileFromDisk(this.certificatePath);
+        const privateKeyString: string = this.loadFileFromDisk(this.privateKeyPath);
+        // TODO: probably need to use a store rather than this as not every config will be an admin
+        this.client.setAdminSigningIdentity(privateKeyString, certString, mspid);
+
+    }
+
+    private loadFileFromDisk(path: string): string {
+        console.log('loadFileFromDisk', path);
+        return fs.readFileSync(path, ENCODING) as string;
+    }
+
+}

--- a/client/src/fabric/FabricConnection.ts
+++ b/client/src/fabric/FabricConnection.ts
@@ -13,7 +13,7 @@
 */
 'use strict';
 import {
-    ChannelQueryResponse, ChaincodeQueryResponse,
+    loadFromConfig, ChannelQueryResponse, ChaincodeQueryResponse,
     Peer, Channel
 } from 'fabric-client';
 import * as Client from 'fabric-client';
@@ -88,6 +88,12 @@ export abstract class FabricConnection {
         });
 
         return instantiatedChaincodes;
+    }
+
+    protected async connectInner(connectionProfile: object, certificate: string, privateKey: string): Promise<void> {
+        this.client = await loadFromConfig(connectionProfile);
+        const mspid: string = this.client.getMspid();
+        this.client.setAdminSigningIdentity(privateKey, certificate, mspid);
     }
 
     private getChannel(channelName: string): Channel {

--- a/client/src/fabric/FabricConnection.ts
+++ b/client/src/fabric/FabricConnection.ts
@@ -13,36 +13,16 @@
 */
 'use strict';
 import {
-    loadFromConfig, ChannelQueryResponse, ChaincodeQueryResponse,
+    ChannelQueryResponse, ChaincodeQueryResponse,
     Peer, Channel
 } from 'fabric-client';
-import * as fs from 'fs';
+import * as Client from 'fabric-client';
 
-const ENCODING = 'utf8';
+export abstract class FabricConnection {
 
-export class FabricClientConnection {
+    protected client: Client;
 
-    private connectionProfilePath: string;
-    private certificatePath: string;
-    private privateKeyPath: string;
-    private client: any;
-
-    constructor(connectionData) {
-        this.connectionProfilePath = connectionData.connectionProfilePath;
-        this.certificatePath = connectionData.certificatePath;
-        this.privateKeyPath = connectionData.privateKeyPath;
-    }
-
-    async connect(): Promise<void> {
-        console.log('connect');
-        this.client = await loadFromConfig(this.connectionProfilePath);
-        const mspid: string = this.client.getMspid();
-        const certString: string = this.loadFileFromDisk(this.certificatePath);
-        const privateKeyString: string = this.loadFileFromDisk(this.privateKeyPath);
-        // TODO: probably need to use a store rather than this as not every config will be an admin
-        this.client.setAdminSigningIdentity(privateKeyString, certString, mspid);
-
-    }
+    abstract async connect(): Promise<void>;
 
     getAllPeerNames(): Array<string> {
         console.log('getAllPeerNames');
@@ -120,8 +100,4 @@ export class FabricClientConnection {
         return this.client.getPeersForOrg(null);
     }
 
-    private loadFileFromDisk(path: string): string {
-        console.log('loadFileFromDisk', path);
-        return fs.readFileSync(path, ENCODING) as string;
-    }
 }

--- a/client/src/fabric/FabricConnectionManager.ts
+++ b/client/src/fabric/FabricConnectionManager.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
 */
 
-import { FabricClientConnection } from '../fabricClientConnection';
+import { FabricConnection } from '../fabric/FabricConnection';
 import { EventEmitter } from 'events';
 
 export class FabricConnectionManager extends EventEmitter {
@@ -23,17 +23,17 @@ export class FabricConnectionManager extends EventEmitter {
 
     private static _instance: FabricConnectionManager = new FabricConnectionManager();
 
-    private connection: FabricClientConnection;
+    private connection: FabricConnection;
 
     private constructor() {
         super();
     }
 
-    public getConnection(): FabricClientConnection {
+    public getConnection(): FabricConnection {
         return this.connection;
     }
 
-    public connect(connection: FabricClientConnection) {
+    public connect(connection: FabricConnection) {
         this.connection = connection;
         this.emit('connected', connection);
     }

--- a/client/src/fabric/FabricConnectionRegistry.ts
+++ b/client/src/fabric/FabricConnectionRegistry.ts
@@ -13,9 +13,9 @@
 */
 
 import { FabricConnectionRegistryEntry } from './FabricConnectionRegistryEntry';
-import { BaseFabricRegistry } from './BaseFabricRegistry';
+import { FabricRegistry } from './FabricRegistry';
 
-export class FabricConnectionRegistry extends BaseFabricRegistry<FabricConnectionRegistryEntry> {
+export class FabricConnectionRegistry extends FabricRegistry<FabricConnectionRegistryEntry> {
 
     public static instance() {
         return FabricConnectionRegistry._instance;

--- a/client/src/fabric/FabricConnectionRegistryEntry.ts
+++ b/client/src/fabric/FabricConnectionRegistryEntry.ts
@@ -12,9 +12,9 @@
  * limitations under the License.
 */
 
-import { BaseFabricRegistryEntry } from './BaseFabricRegistryEntry';
+import { FabricRegistryEntry } from './FabricRegistryEntry';
 
-export class FabricConnectionRegistryEntry extends BaseFabricRegistryEntry {
+export class FabricConnectionRegistryEntry extends FabricRegistryEntry {
 
     public connectionProfilePath: string;
 

--- a/client/src/fabric/FabricRegistry.ts
+++ b/client/src/fabric/FabricRegistry.ts
@@ -13,9 +13,9 @@
 */
 
 import * as vscode from 'vscode';
-import { BaseFabricRegistryEntry } from './BaseFabricRegistryEntry';
+import { FabricRegistryEntry } from './FabricRegistryEntry';
 
-export abstract class BaseFabricRegistry<T extends BaseFabricRegistryEntry> {
+export abstract class FabricRegistry<T extends FabricRegistryEntry> {
 
     protected constructor(private registryName: string) {
 

--- a/client/src/fabric/FabricRegistryEntry.ts
+++ b/client/src/fabric/FabricRegistryEntry.ts
@@ -12,7 +12,7 @@
  * limitations under the License.
 */
 
-export abstract class BaseFabricRegistryEntry {
+export abstract class FabricRegistryEntry {
 
     public name: string;
 

--- a/client/src/fabric/FabricRuntimeConnection.ts
+++ b/client/src/fabric/FabricRuntimeConnection.ts
@@ -11,10 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
 */
+
 'use strict';
-import {
-    loadFromConfig
-} from 'fabric-client';
+
 import { FabricConnection } from './FabricConnection';
 import { FabricRuntime } from './FabricRuntime';
 
@@ -27,12 +26,9 @@ export class FabricRuntimeConnection extends FabricConnection {
     async connect(): Promise<void> {
         console.log('connect');
         const connectionProfile: object = await this.runtime.getConnectionProfile();
-        this.client = await loadFromConfig(connectionProfile);
-        const mspid: string = this.client.getMspid();
-        const certString: string = await this.runtime.getCertificate();
-        const privateKeyString: string = await this.runtime.getPrivateKey();
-        // TODO: probably need to use a store rather than this as not every config will be an admin
-        this.client.setAdminSigningIdentity(privateKeyString, certString, mspid);
+        const certificate: string = await this.runtime.getCertificate();
+        const privateKey: string = await this.runtime.getPrivateKey();
+        await this.connectInner(connectionProfile, certificate, privateKey);
     }
 
 }

--- a/client/src/fabric/FabricRuntimeConnection.ts
+++ b/client/src/fabric/FabricRuntimeConnection.ts
@@ -1,0 +1,38 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+'use strict';
+import {
+    loadFromConfig
+} from 'fabric-client';
+import { FabricConnection } from './FabricConnection';
+import { FabricRuntime } from './FabricRuntime';
+
+export class FabricRuntimeConnection extends FabricConnection {
+
+    constructor(private runtime: FabricRuntime) {
+        super();
+    }
+
+    async connect(): Promise<void> {
+        console.log('connect');
+        const connectionProfile: object = await this.runtime.getConnectionProfile();
+        this.client = await loadFromConfig(connectionProfile);
+        const mspid: string = this.client.getMspid();
+        const certString: string = await this.runtime.getCertificate();
+        const privateKeyString: string = await this.runtime.getPrivateKey();
+        // TODO: probably need to use a store rather than this as not every config will be an admin
+        this.client.setAdminSigningIdentity(privateKeyString, certString, mspid);
+    }
+
+}

--- a/client/src/fabric/FabricRuntimeRegistry.ts
+++ b/client/src/fabric/FabricRuntimeRegistry.ts
@@ -13,9 +13,9 @@
 */
 
 import { FabricRuntimeRegistryEntry } from './FabricRuntimeRegistryEntry';
-import { BaseFabricRegistry } from './BaseFabricRegistry';
+import { FabricRegistry } from './FabricRegistry';
 
-export class FabricRuntimeRegistry extends BaseFabricRegistry<FabricRuntimeRegistryEntry> {
+export class FabricRuntimeRegistry extends FabricRegistry<FabricRuntimeRegistryEntry> {
 
     public static instance() {
         return FabricRuntimeRegistry._instance;

--- a/client/src/fabric/FabricRuntimeRegistryEntry.ts
+++ b/client/src/fabric/FabricRuntimeRegistryEntry.ts
@@ -12,9 +12,9 @@
  * limitations under the License.
 */
 
-import { BaseFabricRegistryEntry } from './BaseFabricRegistryEntry';
+import { FabricRegistryEntry } from './FabricRegistryEntry';
 
-export class FabricRuntimeRegistryEntry extends BaseFabricRegistryEntry {
+export class FabricRuntimeRegistryEntry extends FabricRegistryEntry {
 
     public developmentMode: boolean;
 

--- a/client/test/commands/connectCommand.test.ts
+++ b/client/test/commands/connectCommand.test.ts
@@ -17,7 +17,7 @@ import * as path from 'path';
 
 import * as myExtension from '../../src/extension';
 import * as fabricClient from 'fabric-client';
-import { FabricClientConnection } from '../../src/fabricClientConnection';
+import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';

--- a/client/test/commands/connectCommand.test.ts
+++ b/client/test/commands/connectCommand.test.ts
@@ -288,13 +288,15 @@ describe('ConnectCommand', () => {
             const blockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
             const allChildren: Array<BlockchainTreeItem> = await blockchainNetworkExplorerProvider.getChildren();
 
-            const myConnectionItem: ConnectionTreeItem = allChildren[0] as ConnectionTreeItem;
-
             const errorMessageSpy = mySandBox.spy(vscode.window, 'showErrorMessage');
 
             const loadFromConfigStub = mySandBox.stub(fabricClient, 'loadFromConfig').rejects({message: 'some error'});
 
-            await vscode.commands.executeCommand('blockchainExplorer.connectEntry', myConnectionItem.connection).should.be.rejected;
+            const quickPickStub = mySandBox.stub(vscode.window, 'showQuickPick');
+            quickPickStub.onFirstCall().resolves('myConnection');
+            quickPickStub.onSecondCall().resolves('Admin@org1.example.com');
+
+            await vscode.commands.executeCommand('blockchainExplorer.connectEntry').should.be.rejected;
 
             loadFromConfigStub.should.have.been.called;
 

--- a/client/test/fabric/FabricClientConnection.test.ts
+++ b/client/test/fabric/FabricClientConnection.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { FabricClientConnection } from '../../src/fabric/FabricClientConnection';
+import * as fabricClient from 'fabric-client';
+import * as path from 'path';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+
+chai.should();
+chai.use(sinonChai);
+
+// tslint:disable no-unused-expression
+describe('FabricClientConnection', () => {
+
+    let fabricClientStub: sinon.SinonStubbedInstance<fabricClient>;
+    let fabricClientConnection: FabricClientConnection;
+
+    let mySandBox: sinon.SinonSandbox;
+
+    beforeEach(async () => {
+        mySandBox = sinon.createSandbox();
+
+        const rootPath = path.dirname(__dirname);
+
+        const connectionData = {
+            connectionProfilePath: path.join(rootPath, '../../test/data/connectionOne/connection.json'),
+            certificatePath: path.join(rootPath, '../../test/data/connectionOne/credentials/certificate'),
+            privateKeyPath: path.join(rootPath, '../../test/data/connectionOne/credentials/privateKey')
+        };
+
+        fabricClientConnection = new FabricClientConnection(connectionData);
+
+        fabricClientStub = mySandBox.createStubInstance(fabricClient);
+
+        mySandBox.stub(fabricClient, 'loadFromConfig').resolves(fabricClientStub);
+
+        fabricClientStub.getMspid.returns('myMSPId');
+    });
+
+    afterEach(() => {
+        mySandBox.restore();
+    });
+
+    describe('connect', () => {
+        it('should connect to a fabric', async () => {
+            await fabricClientConnection.connect();
+            fabricClientStub.setAdminSigningIdentity.should.have.been.calledWith(sinon.match.string, sinon.match.string, 'myMSPId');
+        });
+    });
+
+});

--- a/client/test/fabric/FabricConnectionManager.test.ts
+++ b/client/test/fabric/FabricConnectionManager.test.ts
@@ -12,24 +12,31 @@
  * limitations under the License.
 */
 
-import * as vscode from 'vscode';
+import { FabricConnection } from '../../src/fabric/FabricConnection';
 import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
 
 import * as chai from 'chai';
 import * as sinon from 'sinon';
-import { FabricClientConnection } from '../../src/fabricClientConnection';
 
 const should = chai.should();
 
 describe('FabricConnectionManager', () => {
 
+    class TestFabricConnection extends FabricConnection {
+
+        async connect(): Promise<void> {
+            return;
+        }
+
+    }
+
     const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
-    let mockFabricConnection: sinon.SinonStubbedInstance<FabricClientConnection>;
+    let mockFabricConnection: sinon.SinonStubbedInstance<TestFabricConnection>;
     let sandbox: sinon.SinonSandbox;
 
     beforeEach(async () => {
         sandbox = sinon.createSandbox();
-        mockFabricConnection = sinon.createStubInstance(FabricClientConnection);
+        mockFabricConnection = sinon.createStubInstance(TestFabricConnection);
         connectionManager['connection'] = null;
     });
 
@@ -41,7 +48,7 @@ describe('FabricConnectionManager', () => {
     describe('#getConnection', () => {
 
         it('should get the connection', () => {
-            connectionManager['connection'] = ((mockFabricConnection as any) as FabricClientConnection);
+            connectionManager['connection'] = ((mockFabricConnection as any) as FabricConnection);
             connectionManager.getConnection().should.equal(mockFabricConnection);
         });
 
@@ -52,7 +59,7 @@ describe('FabricConnectionManager', () => {
         it('should store the connection and emit an event', () => {
             const listenerStub = sinon.stub();
             connectionManager.once('connected', listenerStub);
-            connectionManager.connect((mockFabricConnection as any) as FabricClientConnection);
+            connectionManager.connect((mockFabricConnection as any) as FabricConnection);
             connectionManager.getConnection().should.equal(mockFabricConnection);
             listenerStub.should.have.been.calledOnceWithExactly(mockFabricConnection);
         });

--- a/client/test/fabric/FabricRegistry.test.ts
+++ b/client/test/fabric/FabricRegistry.test.ts
@@ -13,25 +13,25 @@
 */
 
 import * as vscode from 'vscode';
-import { BaseFabricRegistry } from '../../src/fabric/BaseFabricRegistry';
-import { BaseFabricRegistryEntry } from '../../src/fabric/BaseFabricRegistryEntry';
+import { FabricRegistry } from '../../src/fabric/FabricRegistry';
+import { FabricRegistryEntry } from '../../src/fabric/FabricRegistryEntry';
 
 import * as chai from 'chai';
 
 chai.should();
 
 // tslint:disable no-unused-expression
-describe('BaseFabricRegistry', () => {
+describe('FabricRegistry', () => {
 
     const testFabricRegistryName: string = 'fabric.runtimes';
 
     // tslint:disable max-classes-per-file
-    class TestFabricRegistryEntry extends BaseFabricRegistryEntry {
+    class TestFabricRegistryEntry extends FabricRegistryEntry {
         public myValue: string;
     }
 
     // tslint:disable max-classes-per-file
-    class TestFabricRegistry extends BaseFabricRegistry<TestFabricRegistryEntry> {
+    class TestFabricRegistry extends FabricRegistry<TestFabricRegistryEntry> {
 
         constructor() {
             super(testFabricRegistryName);

--- a/client/test/fabric/FabricRuntimeConnection.test.ts
+++ b/client/test/fabric/FabricRuntimeConnection.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { FabricRuntimeConnection } from '../../src/fabric/FabricRuntimeConnection';
+import * as fabricClient from 'fabric-client';
+import * as path from 'path';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+import * as sinonChai from 'sinon-chai';
+
+chai.should();
+chai.use(sinonChai);
+
+// tslint:disable no-unused-expression
+describe('FabricRuntimeConnection', () => {
+
+    let fabricClientStub: sinon.SinonStubbedInstance<fabricClient>;
+    let fabricRuntimeStub: sinon.SinonStubbedInstance<FabricRuntime>;
+    let fabricRuntimeConnection: FabricRuntimeConnection;
+
+    let mySandBox: sinon.SinonSandbox;
+
+    beforeEach(async () => {
+        mySandBox = sinon.createSandbox();
+
+        const rootPath = path.dirname(__dirname);
+
+        fabricRuntimeStub = sinon.createStubInstance(FabricRuntime);
+        fabricRuntimeStub.getConnectionProfile.resolves({
+            name: 'basic-network',
+            version: '1.0.0',
+            client: {
+                organization: 'Org1',
+                connection: {
+                    timeout: {
+                        peer: {
+                            endorser: '300',
+                            eventHub: '300',
+                            eventReg: '300'
+                        },
+                        orderer: '300'
+                    }
+                }
+            },
+            channels: {
+                mychannel: {
+                    orderers: [
+                        'orderer.example.com'
+                    ],
+                    peers: {
+                        'peer0.org1.example.com': {}
+                    }
+                }
+            },
+            organizations: {
+                Org1: {
+                    mspid: 'Org1MSP',
+                    peers: [
+                        'peer0.org1.example.com'
+                    ],
+                    certificateAuthorities: [
+                        'ca.org1.example.com'
+                    ]
+                }
+            },
+            orderers: {
+                'orderer.example.com': {
+                    url: 'grpc://0.0.0.0:12347'
+                }
+            },
+            peers: {
+                'peer0.org1.example.com': {
+                    url: 'grpc://0.0.0.0:12345',
+                    eventUrl: 'grpc://0.0.0.0:12346'
+                }
+            },
+            certificateAuthorities: {
+                'ca.org1.example.com': {
+                    url: 'http://0.0.0.0:12348',
+                    caName: 'ca.org1.example.com'
+                }
+            }
+        });
+        fabricRuntimeStub.getCertificate.resolves('-----BEGIN CERTIFICATE-----\nMIICGDCCAb+gAwIBAgIQFSxnLAGsu04zrFkAEwzn6zAKBggqhkjOPQQDAjBzMQsw\nCQYDVQQGEwJVUzETMBEGA1UECBMKQ2FsaWZvcm5pYTEWMBQGA1UEBxMNU2FuIEZy\nYW5jaXNjbzEZMBcGA1UEChMQb3JnMS5leGFtcGxlLmNvbTEcMBoGA1UEAxMTY2Eu\nb3JnMS5leGFtcGxlLmNvbTAeFw0xNzA4MzEwOTE0MzJaFw0yNzA4MjkwOTE0MzJa\nMFsxCzAJBgNVBAYTAlVTMRMwEQYDVQQIEwpDYWxpZm9ybmlhMRYwFAYDVQQHEw1T\nYW4gRnJhbmNpc2NvMR8wHQYDVQQDDBZBZG1pbkBvcmcxLmV4YW1wbGUuY29tMFkw\nEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEV1dfmKxsFKWo7o6DNBIaIVebCCPAM9C/\nsLBt4pJRre9pWE987DjXZoZ3glc4+DoPMtTmBRqbPVwYcUvpbYY8p6NNMEswDgYD\nVR0PAQH/BAQDAgeAMAwGA1UdEwEB/wQCMAAwKwYDVR0jBCQwIoAgQjmqDc122u64\nugzacBhR0UUE0xqtGy3d26xqVzZeSXwwCgYIKoZIzj0EAwIDRwAwRAIgXMy26AEU\n/GUMPfCMs/nQjQME1ZxBHAYZtKEuRR361JsCIEg9BOZdIoioRivJC+ZUzvJUnkXu\no2HkWiuxLsibGxtE\n-----END CERTIFICATE-----\n');
+        fabricRuntimeStub.getPrivateKey.resolves('-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgRgQr347ij6cjwX7m\nKjzbbD8Tlwdfu6FaubjWJWLGyqahRANCAARXV1+YrGwUpajujoM0EhohV5sII8Az\n0L+wsG3iklGt72lYT3zsONdmhneCVzj4Og8y1OYFGps9XBhxS+lthjyn\n-----END PRIVATE KEY-----\n');
+
+        fabricRuntimeConnection = new FabricRuntimeConnection((fabricRuntimeStub as any) as FabricRuntime);
+
+        fabricClientStub = mySandBox.createStubInstance(fabricClient);
+
+        mySandBox.stub(fabricClient, 'loadFromConfig').resolves(fabricClientStub);
+
+        fabricClientStub.getMspid.returns('myMSPId');
+    });
+
+    afterEach(() => {
+        mySandBox.restore();
+    });
+
+    describe('connect', () => {
+        it('should connect to a fabric', async () => {
+            await fabricRuntimeConnection.connect();
+            fabricClientStub.setAdminSigningIdentity.should.have.been.calledWith(sinon.match(/-----BEGIN PRIVATE KEY-----/), sinon.match(/-----BEGIN CERTIFICATE-----/), 'myMSPId');
+        });
+    });
+
+});


### PR DESCRIPTION
Enable connections to a managed runtime from within the Visual Studio Code connection.
The difference between a client connection and a runtime connection is that a client connection requires a connection profile path, certificate path, and private key path - where instead a runtime connection has all these things in memory. These differences are limited to the `connect()` method.

So...

- The bulk (all except `connect()`) of FabricClientConnection moves into a base abstract class FabricConnection.
- FabricClientConnection becomes much smaller (only `connect()`), and extends FabricConnection.
- Runtime connections are implemented in FabricRuntimeConnection, and extends FabricConnection.

Also I decided that BaseFabricRegistry is a sucky name, so I renamed it to FabricRegistry.