### PR TITLE
Enable connecting to a managed runtime from command and tree

### DIFF
--- a/client/.istanbul.yml
+++ b/client/.istanbul.yml
@@ -13,7 +13,7 @@ instrumentation:
 
 check:
     global:
-        statements: 92.29
-        branches: 96.41
-        functions: 91.72
-        lines: 96.01
+        statements: 93.34
+        branches: 97.21
+        functions: 94.02
+        lines: 96.82

--- a/client/.istanbul.yml
+++ b/client/.istanbul.yml
@@ -13,7 +13,7 @@ instrumentation:
 
 check:
     global:
-        statements: 93.34
+        statements: 93.52
         branches: 97.21
         functions: 94.02
-        lines: 96.82
+        lines: 97.03

--- a/client/src/commands/connectCommand.ts
+++ b/client/src/commands/connectCommand.ts
@@ -23,6 +23,7 @@ import { FabricConnectionRegistry } from '../fabric/FabricConnectionRegistry';
 import { FabricConnection } from '../fabric/FabricConnection';
 import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
 import { FabricRuntimeConnection } from '../fabric/FabricRuntimeConnection';
+import { FabricRuntime } from '../fabric/FabricRuntime';
 
 export async function connect(connectionName: string, identityName?: string): Promise<void> {
     console.log('connect', connectionName, identityName);
@@ -44,8 +45,8 @@ export async function connect(connectionName: string, identityName?: string): Pr
     let connection: FabricConnection;
     if (connectionRegistryEntry.managedRuntime) {
 
-        const runtimeManager = FabricRuntimeManager.instance();
-        const runtime = runtimeManager.get(connectionName);
+        const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+        const runtime: FabricRuntime = runtimeManager.get(connectionName);
         connection = new FabricRuntimeConnection(runtime);
 
     } else {

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -34,7 +34,7 @@ export function activate(context: vscode.ExtensionContext): void {
     vscode.window.registerTreeDataProvider('blockchainExplorer', blockchainNetworkExplorerProvider);
     vscode.window.registerTreeDataProvider('blockchainAPackageExplorer', blockchainPackageExplorerProvider);
     vscode.commands.registerCommand('blockchainExplorer.refreshEntry', (element) => blockchainNetworkExplorerProvider.refresh(element));
-    vscode.commands.registerCommand('blockchainExplorer.connectEntry', (connection) => connect(connection));
+    vscode.commands.registerCommand('blockchainExplorer.connectEntry', (connectionName, identityName) => connect(connectionName, identityName));
     vscode.commands.registerCommand('blockchainExplorer.disconnectEntry', () => blockchainNetworkExplorerProvider.disconnect());
     vscode.commands.registerCommand('blockchainExplorer.addConnectionEntry', addConnection);
     vscode.commands.registerCommand('blockchainExplorer.deleteConnectionEntry', (connection) => deleteConnection(connection));
@@ -45,7 +45,7 @@ export function activate(context: vscode.ExtensionContext): void {
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e) => {
 
-        if (e.affectsConfiguration('fabric.connections')) {
+        if (e.affectsConfiguration('fabric.connections') || e.affectsConfiguration('fabric.runtimes')) {
             return vscode.commands.executeCommand('blockchainExplorer.refreshEntry');
         }
     }));

--- a/client/src/fabric/FabricClientConnection.ts
+++ b/client/src/fabric/FabricClientConnection.ts
@@ -27,7 +27,7 @@ export class FabricClientConnection extends FabricConnection {
     private certificatePath: string;
     private privateKeyPath: string;
 
-    constructor(connectionData) {
+    constructor(connectionData: { connectionProfilePath: string, certificatePath: string, privateKeyPath: string }) {
         super();
         this.connectionProfilePath = connectionData.connectionProfilePath;
         this.certificatePath = connectionData.certificatePath;

--- a/client/test/explorer/blockchainNetworkExplorer.test.ts
+++ b/client/test/explorer/blockchainNetworkExplorer.test.ts
@@ -192,16 +192,10 @@ describe('BlockchainNetworkExplorer', () => {
                 const blockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
                 const allChildren = await blockchainNetworkExplorerProvider.getChildren();
 
-                const myCommandConnection = {
-                    connectionProfilePath: myConnection.connectionProfilePath,
-                    certificatePath: myConnection.identities[0].certificatePath,
-                    privateKeyPath: myConnection.identities[0].privateKeyPath
-                };
-
                 const myCommand = {
                     command: 'blockchainExplorer.connectEntry',
                     title: '',
-                    arguments: [myCommandConnection]
+                    arguments: ['myConnection']
                 };
 
                 allChildren.length.should.equal(2);
@@ -234,20 +228,6 @@ describe('BlockchainNetworkExplorer', () => {
                         }]
                 };
 
-                const myConnectionIdentityOne = {
-                    name: myConnection.name,
-                    connectionProfilePath: myConnection.connectionProfilePath,
-                    certificatePath: myConnection.identities[0].certificatePath,
-                    privateKeyPath: myConnection.identities[0].privateKeyPath
-                };
-
-                const myConnectionIdentityTwo = {
-                    name: myConnection.name,
-                    connectionProfilePath: myConnection.connectionProfilePath,
-                    certificatePath: myConnection.identities[1].certificatePath,
-                    privateKeyPath: myConnection.identities[1].privateKeyPath
-                };
-
                 connections.push(myConnection);
 
                 await vscode.workspace.getConfiguration().update('fabric.connections', connections, vscode.ConfigurationTarget.Global);
@@ -267,13 +247,13 @@ describe('BlockchainNetworkExplorer', () => {
                 const myCommandOne = {
                     command: 'blockchainExplorer.connectEntry',
                     title: '',
-                    arguments: [myConnectionIdentityOne]
+                    arguments: ['myConnection', 'Admin@org1.example.com']
                 };
 
                 const myCommandTwo = {
                     command: 'blockchainExplorer.connectEntry',
                     title: '',
-                    arguments: [myConnectionIdentityTwo]
+                    arguments: ['myConnection', 'Admin@org1.example.com']
                 };
 
                 const identityChildren = await blockchainNetworkExplorerProvider.getChildren(connectionTreeItem);
@@ -370,6 +350,39 @@ describe('BlockchainNetworkExplorer', () => {
 
                 errorSpy.should.have.been.calledWith('some error');
             });
+
+            it('should display managed runtimes with single identities', async () => {
+                await vscode.extensions.getExtension('hyperledger.hyperledger-fabric').activate();
+
+                const connections: Array<any> = [];
+
+                const myConnection = {
+                    name: 'myRuntimeConnection',
+                    managedRuntime: true
+                };
+
+                connections.push(myConnection);
+
+                await vscode.workspace.getConfiguration().update('fabric.connections', connections, vscode.ConfigurationTarget.Global);
+
+                const blockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+                const allChildren = await blockchainNetworkExplorerProvider.getChildren();
+
+                const myCommand = {
+                    command: 'blockchainExplorer.connectEntry',
+                    title: '',
+                    arguments: ['myRuntimeConnection']
+                };
+
+                allChildren.length.should.equal(2);
+                const connectionTreeItem = allChildren[0] as ConnectionTreeItem;
+                connectionTreeItem.label.should.equal('myRuntimeConnection');
+                connectionTreeItem.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
+                connectionTreeItem.connection.should.deep.equal(myConnection);
+                connectionTreeItem.command.should.deep.equal(myCommand);
+                allChildren[1].label.should.equal('Add new network');
+            });
+
         });
 
         describe('connected tree', () => {

--- a/client/test/explorer/blockchainNetworkExplorer.test.ts
+++ b/client/test/explorer/blockchainNetworkExplorer.test.ts
@@ -71,6 +71,21 @@ describe('BlockchainNetworkExplorer', () => {
             blockchainNetworkExplorerProvider.connect.should.have.been.calledOnceWithExactly(mockConnection);
         });
 
+        it('should display errors from connected events', async () => {
+            await vscode.extensions.getExtension('hyperledger.hyperledger-fabric').activate();
+            const blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'connect').rejects(new Error('wow such error'));
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'disconnect').resolves();
+            const mockConnection: sinon.SinonStubbedInstance<TestFabricConnection> = sinon.createStubInstance(TestFabricConnection);
+            const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
+            const showErrorMessageSpy: sinon.SinonSpy = mySandBox.spy(vscode.window, 'showErrorMessage');
+            connectionManager.emit('connected', mockConnection);
+            // Need to ensure the event handler gets a chance to run.
+            await new Promise((resolve, reject) => setTimeout(resolve, 50));
+            blockchainNetworkExplorerProvider.connect.should.have.been.calledOnceWithExactly(mockConnection);
+            showErrorMessageSpy.should.have.been.calledOnceWithExactly('Error handling connected event: wow such error');
+        });
+
         it('should register for disconnected events from the connection manager', async () => {
             await vscode.extensions.getExtension('hyperledger.hyperledger-fabric').activate();
             const blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
@@ -79,6 +94,20 @@ describe('BlockchainNetworkExplorer', () => {
             const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
             connectionManager.emit('disconnected');
             blockchainNetworkExplorerProvider.disconnect.should.have.been.calledOnceWithExactly();
+        });
+
+        it('should display errors from disconnected events', async () => {
+            await vscode.extensions.getExtension('hyperledger.hyperledger-fabric').activate();
+            const blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'connect').resolves();
+            mySandBox.stub(blockchainNetworkExplorerProvider, 'disconnect').rejects(new Error('wow such error'));
+            const connectionManager: FabricConnectionManager = FabricConnectionManager.instance();
+            const showErrorMessageSpy: sinon.SinonSpy = mySandBox.spy(vscode.window, 'showErrorMessage');
+            connectionManager.emit('disconnected');
+            // Need to ensure the event handler gets a chance to run.
+            await new Promise((resolve, reject) => setTimeout(resolve, 50));
+            blockchainNetworkExplorerProvider.disconnect.should.have.been.calledOnceWithExactly();
+            showErrorMessageSpy.should.have.been.calledOnceWithExactly('Error handling disconnected event: wow such error');
         });
 
     });

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -88,4 +88,23 @@ describe('Extension Tests', () => {
 
         treeSpy.should.have.been.called;
     });
+
+    it('should refresh the tree when a runtime is added', async () => {
+        await vscode.workspace.getConfiguration().update('fabric.runtimes', [], vscode.ConfigurationTarget.Global);
+
+        await vscode.extensions.getExtension('hyperledger.hyperledger-fabric').activate();
+
+        const treeDataProvider = myExtension.getBlockchainNetworkExplorerProvider();
+
+        const treeSpy = mySandBox.spy(treeDataProvider['_onDidChangeTreeData'], 'fire');
+
+        const myRuntime = {
+            name: 'myRuntime',
+            developmentMode: false
+        };
+
+        await vscode.workspace.getConfiguration().update('fabric.runtimes', [myRuntime], vscode.ConfigurationTarget.Global);
+
+        treeSpy.should.have.been.called;
+    });
 });


### PR DESCRIPTION
Enable the Visual Studio Code extension to connect to a managed runtime, both from the existing `Blockchain: Connect` command and the connection tree.

This change:
- Updates the `connect` command to take a connection name and an optional identity name, and it then creates a client or runtime connection as appropriate. Beforehand it used to accept a `fabricConnection` object which had a connection profile path, private key path, and certificate path - these are found from within the `connect` command now.
- Updates the tree to handle the updates to the `connect` command, and correctly display connections to managed runtime - which have no identities array.
- Automatically refreshes the tree when the managed runtime configuration changes.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>