### PR TITLE
Automatically create local_fabric runtime on activation

### DIFF
--- a/client/src/explorer/BlockchainNetworkExplorer.ts
+++ b/client/src/explorer/BlockchainNetworkExplorer.ts
@@ -34,6 +34,8 @@ import { FabricConnectionManager } from '../fabric/FabricConnectionManager';
 import { BlockchainExplorerProvider } from './BlockchainExplorerProvider';
 import { FabricConnectionRegistryEntry } from '../fabric/FabricConnectionRegistryEntry';
 import { FabricConnectionRegistry } from '../fabric/FabricConnectionRegistry';
+import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
+import { RuntimeTreeItem } from './model/RuntimeTreeItem';
 
 export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProvider {
 
@@ -47,6 +49,7 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
     private connection: IFabricConnection = null;
 
     private connectionRegistryManager: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+    private runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
 
     constructor() {
         FabricConnectionManager.instance().on('connected', async (connection: IFabricConnection) => {
@@ -291,11 +294,19 @@ export class BlockchainNetworkExplorerProvider implements BlockchainExplorerProv
                 };
             }
 
-            tree.push(new ConnectionTreeItem(this,
-                connection.name,
-                connection,
-                collapsibleState,
-                command));
+            if (connection.managedRuntime) {
+                tree.push(new RuntimeTreeItem(this,
+                    connection.name,
+                    connection,
+                    collapsibleState,
+                    command));
+            } else {
+                tree.push(new ConnectionTreeItem(this,
+                    connection.name,
+                    connection,
+                    collapsibleState,
+                    command));
+            }
         }
 
         tree.sort((connectionA, connectionB) => {

--- a/client/src/explorer/model/RuntimeTreeItem.ts
+++ b/client/src/explorer/model/RuntimeTreeItem.ts
@@ -1,0 +1,27 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+'use strict';
+
+import * as vscode from 'vscode';
+import { ConnectionTreeItem } from './ConnectionTreeItem';
+import { BlockchainExplorerProvider } from '../BlockchainExplorerProvider';
+
+export class RuntimeTreeItem extends ConnectionTreeItem {
+    contextValue = 'blockchain-runtime-item';
+
+    constructor(provider: BlockchainExplorerProvider, public readonly label: string, public readonly connection: any, public readonly collapsableState: vscode.TreeItemCollapsibleState, public readonly command?: vscode.Command) {
+        super(provider, label, connection, collapsableState, command);
+    }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -26,6 +26,7 @@ import { VSCodeOutputAdapter } from './logging/VSCodeOutputAdapter';
 import { DependencyManager } from './dependencies/DependencyManager';
 import { TemporaryCommandRegistry } from './dependencies/TemporaryCommandRegistry';
 import { ExtensionUtil } from './util/ExtensionUtil';
+import { FabricRuntimeManager } from './fabric/FabricRuntimeManager';
 
 let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -46,6 +47,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         } else {
             registerCommands(context);
         }
+
+        await ensureLocalFabricExists();
 
         ExtensionUtil.setExtensionContext(context);
         outputAdapter.log('extension activated');
@@ -90,6 +93,14 @@ export function registerCommands(context: vscode.ExtensionContext): void {
             return vscode.commands.executeCommand('blockchainExplorer.refreshEntry');
         }
     }));
+}
+
+export async function ensureLocalFabricExists(): Promise<void> {
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+    if (runtimeManager.exists('local_fabric')) {
+        return;
+    }
+    await runtimeManager.add('local_fabric');
 }
 
 function disposeExtension(context: vscode.ExtensionContext): void {

--- a/client/test/explorer/blockchainNetworkExplorer.test.ts
+++ b/client/test/explorer/blockchainNetworkExplorer.test.ts
@@ -35,6 +35,7 @@ import { InstalledChainCodeVersionTreeItem } from '../../src/explorer/model/Inst
 import { FabricConnectionManager } from '../../src/fabric/FabricConnectionManager';
 import { ExtensionUtil } from '../../src/util/ExtensionUtil';
 import { TestUtil } from '../TestUtil';
+import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
 
 chai.use(sinonChai);
 const should = chai.should();
@@ -388,11 +389,12 @@ describe('BlockchainNetworkExplorer', () => {
                 };
 
                 allChildren.length.should.equal(2);
-                const connectionTreeItem = allChildren[0] as ConnectionTreeItem;
-                connectionTreeItem.label.should.equal('myRuntimeConnection');
-                connectionTreeItem.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
-                connectionTreeItem.connection.should.deep.equal(myConnection);
-                connectionTreeItem.command.should.deep.equal(myCommand);
+                allChildren[0].should.be.an.instanceOf(RuntimeTreeItem);
+                const runtimeTreeItem = allChildren[0] as RuntimeTreeItem;
+                runtimeTreeItem.label.should.equal('myRuntimeConnection');
+                runtimeTreeItem.collapsibleState.should.equal(vscode.TreeItemCollapsibleState.None);
+                runtimeTreeItem.connection.should.deep.equal(myConnection);
+                runtimeTreeItem.command.should.deep.equal(myCommand);
                 allChildren[1].label.should.equal('Add new connection');
             });
 

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -23,6 +23,7 @@ import { DependencyManager } from '../src/dependencies/DependencyManager';
 import { VSCodeOutputAdapter } from '../src/logging/VSCodeOutputAdapter';
 import { TemporaryCommandRegistry } from '../src/dependencies/TemporaryCommandRegistry';
 import { TestUtil } from './TestUtil';
+import { FabricRuntimeManager } from '../src/fabric/FabricRuntimeManager';
 
 chai.should();
 chai.use(sinonChai);
@@ -31,6 +32,7 @@ chai.use(sinonChai);
 describe('Extension Tests', () => {
 
     let mySandBox;
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
 
     before(async () => {
         await TestUtil.setupTests();
@@ -38,10 +40,16 @@ describe('Extension Tests', () => {
 
     beforeEach(async () => {
         mySandBox = sinon.createSandbox();
+        if (runtimeManager.exists('local_fabric')) {
+            await runtimeManager.delete('local_fabric');
+        }
     });
 
-    afterEach(() => {
+    afterEach(async () => {
         mySandBox.restore();
+        if (runtimeManager.exists('local_fabric')) {
+            await runtimeManager.delete('local_fabric');
+        }
     });
 
     it('should check all the commands are registered', async () => {
@@ -181,4 +189,20 @@ describe('Extension Tests', () => {
 
         await vscode.commands.executeCommand('blockchain.refreshEntry').should.be.rejectedWith(`command 'blockchain.refreshEntry' not found`);
     });
+
+    it('should create a new local_fabric if one does not exist', async () => {
+        const addSpy = mySandBox.spy(runtimeManager, 'add');
+        const context: vscode.ExtensionContext = ExtensionUtil.getExtensionContext();
+        await myExtension.activate(context);
+        addSpy.should.have.been.calledOnceWithExactly('local_fabric');
+    });
+
+    it('should not create a new local_fabric if one already exists', async () => {
+        await runtimeManager.add('local_fabric');
+        const addSpy = mySandBox.spy(runtimeManager, 'add');
+        const context: vscode.ExtensionContext = ExtensionUtil.getExtensionContext();
+        await myExtension.activate(context);
+        addSpy.should.not.have.been.called;
+    });
+
 });


### PR DESCRIPTION
Automatically create a managed Fabric runtime called `local_fabric` during activation of the extension. Also, to allow for separate commands/menus between remote Fabric connections and managed Fabric runtimes, create a new tree element of type `RuntimeTreeItem`.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>