### PR TITLE
Add command to start local_fabric runtime

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -40,7 +40,8 @@
       "blockchainExplorer.refreshEntry",
       "blockchain.createSmartContractProjectEntry",
       "blockchainAPackageExplorer.refreshEntry",
-      "blockchainAPackageExplorer.packageSmartContractProject"
+      "blockchainAPackageExplorer.packageSmartContractProject",
+      "blockchainExplorer.startFabricRuntime"
     ]
   },
   "main": "./out/src/extension",
@@ -157,6 +158,11 @@
           "dark": "resources/dark/add.svg"
         },
         "category": "Blockchain"
+      },
+      {
+        "command": "blockchainExplorer.startFabricRuntime",
+        "title": "Start Fabric Runtime",
+        "category": "Blockchain"
       }
     ],
     "menus": {
@@ -199,6 +205,10 @@
         {
           "command": "blockchainExplorer.addConnectionIdentityEntry",
           "when": "view == blockchainExplorer && viewItem == blockchain-connection-item"
+        },
+        {
+          "command": "blockchainExplorer.startFabricRuntime",
+          "when": "view == blockchainExplorer && viewItem == blockchain-runtime-item"
         }
       ]
     }

--- a/client/src/commands/commandsUtil.ts
+++ b/client/src/commands/commandsUtil.ts
@@ -14,6 +14,8 @@
 'use strict';
 import * as vscode from 'vscode';
 import { ParsedCertificate } from '../fabric/ParsedCertificate';
+import { FabricRuntimeRegistry } from '../fabric/FabricRuntimeRegistry';
+import { FabricRuntimeRegistryEntry } from '../fabric/FabricRuntimeRegistryEntry';
 
 export class CommandsUtil {
 
@@ -59,4 +61,18 @@ export class CommandsUtil {
 
         return vscode.window.showQuickPick(identityNames, quickPickOptions);
     }
+
+    static showRuntimeQuickPickBox(prompt: string): Thenable<string | undefined> {
+        const runtimes: FabricRuntimeRegistryEntry[] = FabricRuntimeRegistry.instance().getAll();
+        const runtimeNames: string[] = runtimes.map((runtime: FabricRuntimeRegistryEntry) => runtime.name);
+
+        const quickPickOptions = {
+            ignoreFocusOut: false,
+            canPickMany: false,
+            placeHolder: prompt
+        };
+
+        return vscode.window.showQuickPick(runtimeNames, quickPickOptions);
+    }
+
 }

--- a/client/src/commands/startFabricRuntime.ts
+++ b/client/src/commands/startFabricRuntime.ts
@@ -1,0 +1,39 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import { FabricRuntimeManager } from '../fabric/FabricRuntimeManager';
+import { CommandsUtil } from './commandsUtil';
+import { RuntimeTreeItem } from '../explorer/model/RuntimeTreeItem';
+import { VSCodeOutputAdapter } from '../logging/VSCodeOutputAdapter';
+
+export async function startFabricRuntime(runtimeTreeItem?: RuntimeTreeItem): Promise<void> {
+    const runtimeManager = FabricRuntimeManager.instance();
+    let runtimeName;
+    if (!runtimeTreeItem) {
+        runtimeName = await CommandsUtil.showRuntimeQuickPickBox('Enter a name for the runtime');
+    } else {
+        runtimeName = runtimeTreeItem.label;
+    }
+    const runtime = runtimeManager.get(runtimeName);
+    await vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: 'Blockchain Extension',
+        cancellable: false
+    }, async (progress, token) => {
+        progress.report({ message: `Starting Fabric runtime ${runtimeName}` });
+        const outputAdapter: VSCodeOutputAdapter = VSCodeOutputAdapter.instance();
+        await runtime.start(outputAdapter);
+    });
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -27,6 +27,8 @@ import { DependencyManager } from './dependencies/DependencyManager';
 import { TemporaryCommandRegistry } from './dependencies/TemporaryCommandRegistry';
 import { ExtensionUtil } from './util/ExtensionUtil';
 import { FabricRuntimeManager } from './fabric/FabricRuntimeManager';
+import { RuntimeTreeItem } from './explorer/model/RuntimeTreeItem';
+import { startFabricRuntime } from './commands/startFabricRuntime';
 
 let blockchainNetworkExplorerProvider: BlockchainNetworkExplorerProvider;
 let blockchainPackageExplorerProvider: BlockchainPackageExplorerProvider;
@@ -86,6 +88,7 @@ export function registerCommands(context: vscode.ExtensionContext): void {
     context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.addConnectionIdentityEntry', (connection) => addConnectionIdentity(connection)));
     context.subscriptions.push(vscode.commands.registerCommand('blockchain.createSmartContractProjectEntry', createSmartContractProject));
     context.subscriptions.push(vscode.commands.registerCommand('blockchainAPackageExplorer.refreshEntry', () => blockchainPackageExplorerProvider.refresh()));
+    context.subscriptions.push(vscode.commands.registerCommand('blockchainExplorer.startFabricRuntime', (runtimeTreeItem?: RuntimeTreeItem) => startFabricRuntime(runtimeTreeItem)));
 
     context.subscriptions.push(vscode.workspace.onDidChangeConfiguration((e) => {
 

--- a/client/test/commands/startFabricRuntime.test.ts
+++ b/client/test/commands/startFabricRuntime.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+import * as vscode from 'vscode';
+import * as myExtension from '../../src/extension';
+import { FabricConnectionRegistry } from '../../src/fabric/FabricConnectionRegistry';
+import { FabricRuntimeRegistry } from '../../src/fabric/FabricRuntimeRegistry';
+import { FabricRuntimeManager } from '../../src/fabric/FabricRuntimeManager';
+import { ExtensionUtil } from '../../src/util/ExtensionUtil';
+import { FabricRuntime } from '../../src/fabric/FabricRuntime';
+import { VSCodeOutputAdapter } from '../../src/logging/VSCodeOutputAdapter';
+import { BlockchainNetworkExplorerProvider } from '../../src/explorer/BlockchainNetworkExplorer';
+import { BlockchainTreeItem } from '../../src/explorer/model/BlockchainTreeItem';
+import { RuntimeTreeItem } from '../../src/explorer/model/RuntimeTreeItem';
+import { CommandsUtil } from '../../src/commands/commandsUtil';
+
+import * as chai from 'chai';
+import * as sinon from 'sinon';
+chai.should();
+
+// tslint:disable no-unused-expression
+describe('startFabricRuntime', () => {
+
+    let sandbox: sinon.SinonSandbox;
+    const connectionRegistry: FabricConnectionRegistry = FabricConnectionRegistry.instance();
+    const runtimeRegistry: FabricRuntimeRegistry = FabricRuntimeRegistry.instance();
+    const runtimeManager: FabricRuntimeManager = FabricRuntimeManager.instance();
+    let runtime: FabricRuntime;
+    let runtimeTreeItem: RuntimeTreeItem;
+
+    beforeEach(async () => {
+        sandbox = sinon.createSandbox();
+        await ExtensionUtil.activateExtension();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+        await runtimeManager.add('local_fabric');
+        runtime = runtimeManager.get('local_fabric');
+        const provider: BlockchainNetworkExplorerProvider = myExtension.getBlockchainNetworkExplorerProvider();
+        const children: BlockchainTreeItem[] = await provider.getChildren();
+        runtimeTreeItem = children.find((child: BlockchainTreeItem) => child instanceof RuntimeTreeItem) as RuntimeTreeItem;
+    });
+
+    afterEach(async () => {
+        sandbox.restore();
+        await connectionRegistry.clear();
+        await runtimeRegistry.clear();
+        await runtimeManager.clear();
+    });
+
+    it('should start a Fabric runtime specified by right clicking the tree', async () => {
+        const startStub: sinon.SinonStub = sandbox.stub(runtime, 'start').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.startFabricRuntime', runtimeTreeItem);
+        startStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+    it('should start a Fabric runtime specified by selecting it from the quick pick', async () => {
+        const quickPickStub: sinon.SinonStub = sandbox.stub(CommandsUtil, 'showRuntimeQuickPickBox').resolves('local_fabric');
+        const startStub: sinon.SinonStub = sandbox.stub(runtime, 'start').resolves();
+        await vscode.commands.executeCommand('blockchainExplorer.startFabricRuntime');
+        quickPickStub.should.have.been.called.calledOnce;
+        startStub.should.have.been.called.calledOnceWithExactly(VSCodeOutputAdapter.instance());
+    });
+
+});

--- a/client/test/extension.test.ts
+++ b/client/test/extension.test.ts
@@ -67,7 +67,8 @@ describe('Extension Tests', () => {
             'blockchainExplorer.deleteConnectionEntry',
             'blockchainExplorer.addConnectionIdentityEntry',
             'blockchain.createSmartContractProjectEntry',
-            'blockchainAPackageExplorer.refreshEntry'
+            'blockchainAPackageExplorer.refreshEntry',
+            'blockchainExplorer.startFabricRuntime'
         ]);
     });
 
@@ -86,6 +87,7 @@ describe('Extension Tests', () => {
             'onCommand:blockchain.createSmartContractProjectEntry',
             'onCommand:blockchainAPackageExplorer.refreshEntry',
             'onCommand:blockchainAPackageExplorer.packageSmartContractProject',
+            'onCommand:blockchainExplorer.startFabricRuntime'
         ]);
     });
 


### PR DESCRIPTION
Add a new command, `Start Fabric Runtime`, that allows a user of the extension to start the automatically created `local_fabric` runtime delivered in PR #26.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>